### PR TITLE
ci: Use Node 24.15 instead of latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version: "24.15" # 24.16 breaks Chrome tests
+          #node-version: "lts/*"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
There's a bug in some combination of Node 24.16, Chrome, and an unzip package that leads to things hanging. The common workaround people are using seems to be rolling back the node version to the previous minor, so let's do that.